### PR TITLE
rework sponsor images

### DIFF
--- a/components/SponsorImage.vue
+++ b/components/SponsorImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <a class="link" style="position: relative;" :href="formatURL(item.url)" target="_blank" rel="noopener noreferrer">
+  <a class="link" :href="formatURL(item.url)" target="_blank" rel="noopener noreferrer">
     <img
       :class="{hasAlt: item.altImageUrl, [item.rank]: true, default: !item.altImageUrl}"
       :src="item.imageURL"
@@ -44,6 +44,10 @@ img {
 .default:hover {
   filter: none;
 }
+.link {
+  display: block;
+  position: relative;
+}
 .link img{
   transition: 0.5s, -moz-filter 0.5s, -o-filter 0.5s, filter 0.5s;
 }
@@ -54,7 +58,7 @@ img {
   opacity: 1;
 }
 .link .altImage {
-  top: -100;
+  top: 0;
   left: 0;
   position: absolute;
   opacity: 1;

--- a/components/SponsorImage.vue
+++ b/components/SponsorImage.vue
@@ -36,8 +36,10 @@ export default {
 <style scoped>
 .default {
   transition: 0.5s, -moz-filter 0.5s, -o-filter 0.5s, filter 0.5s;
-  width: 100%;
   filter: brightness(0) invert(1);
+}
+img {
+  width: 100%;
 }
 .default:hover {
   filter: none;
@@ -61,18 +63,23 @@ export default {
   opacity: 0;
 }
 .tera {
-  width: 400px;
+  max-width: 230px;
+  max-height: 230px;
 }
 .giga {
-  max-width: 350px;
+  max-width: 200px;
+  max-height: 200px;
 }
 .mega {
-  max-width: 300px;
+  max-width: 170px;
+  max-height: 170px;
 }
 .kilo {
-  max-width: 225px;
+  max-width: 140px;
+  max-height: 140px;
 }
 .in-kind {
-  max-width: 150px;
+  max-width: 110px;
+  max-height: 110px;
 }
 </style>

--- a/components/Sponza.vue
+++ b/components/Sponza.vue
@@ -4,71 +4,33 @@
       Sponsors
     </p>
     <br>
-    <!--  -->
-    <div id="sponsors-list" :class="is-flex">
-      <div class="columns is-multiline is-vcentered is-centered">
-        <div v-for="item in items" :key="item.name">
-          <div v-if="item.rank == 'tera'">
-            <div class="column">
-              <SponsorImage :item="item" />
-            </div>
-          </div>
-        </div>
+
+    <div id="sponsors-list" class="sponsorCategory">
+      <div v-for="item in listOfTera" :key="item.name" class="sponsorWrapper">
+        <SponsorImage :item="item" />
       </div>
     </div>
-    <!--  -->
-    <!--  -->
-    <div id="sponsors-list" :class="is-flex">
-      <div class="columns is-multiline is-vcentered is-centered">
-        <div v-for="item in items" :key="item.name">
-          <div v-if="item.rank == 'giga'">
-            <div class="column">
-              <SponsorImage :item="item" />
-            </div>
-          </div>
-        </div>
+    <div id="sponsors-list" class="sponsorCategory">
+      <div v-for="item in listOfGiga" :key="item.name" class="sponsorWrapper">
+        <SponsorImage :item="item" />
       </div>
     </div>
-    <!--  -->
-    <!--  -->
-    <div id="sponsors-list" :class="is-flex">
-      <div class="columns is-multiline is-vcentered is-centered">
-        <div v-for="item in items" :key="item.name">
-          <div v-if="item.rank == 'mega'">
-            <div class="column">
-              <SponsorImage :item="item" />
-            </div>
-          </div>
-        </div>
+    <div id="sponsors-list" class="sponsorCategory">
+      <div v-for="item in listOfMega" :key="item.name" class="sponsorWrapper">
+        <SponsorImage :item="item" />
       </div>
     </div>
-    <!--  -->
-    <!--  -->
-    <div id="sponsors-list" :class="is-flex">
-      <div class="columns is-multiline is-vcentered is-centered">
-        <div v-for="item in items" :key="item.name">
-          <div v-if="item.rank == 'kilo'">
-            <div class="column">
-              <SponsorImage :item="item" />
-            </div>
-          </div>
-        </div>
+    <div id="sponsors-list" class="sponsorCategory">
+      <div v-for="item in listOfKilo" :key="item.name" class="sponsorWrapper">
+        <SponsorImage :item="item" />
       </div>
     </div>
-    <!--  -->
-    <!--  -->
-    <div id="sponsors-list" :class="is-flex">
-      <div class="columns is-multiline is-vcentered is-centered">
-        <div v-for="item in items" :key="item.name">
-          <div v-if="item.rank == 'in-kind'">
-            <div class="column">
-              <SponsorImage :item="item" />
-            </div>
-          </div>
-        </div>
+    <div id="sponsors-list" class="sponsorCategory">
+      <div v-for="item in listOfInKind" :key="item.name" class="sponsorWrapper">
+        <SponsorImage :item="item" />
       </div>
     </div>
-    <!--  -->
+
     <a href="mailto:logistics@nwplus.io">
       <img
         class="becomeSponsor"
@@ -89,6 +51,13 @@ export default {
       type: Array,
       required: true
     }
+  },
+  computed: {
+    listOfTera: function () { return this.items.filter(item => item.rank === 'tera') },
+    listOfGiga: function () { return this.items.filter(item => item.rank === 'giga') },
+    listOfMega: function () { return this.items.filter(item => item.rank === 'mega') },
+    listOfKilo: function () { return this.items.filter(item => item.rank === 'kilo') },
+    listOfInKind: function () { return this.items.filter(item => item.rank === 'in-kind') }
   }
 }
 </script>
@@ -98,14 +67,11 @@ export default {
 $heading-font: "Caveat Brush";
 //Desktop CSS:
 .becomeSponsor {
-  transition-duration: 0.5s;
+  transition-duration: 0.3s;
   width: auto;
 }
 .becomeSponsor:hover {
   transform: scale(1.1);
-}
-.columns {
-  margin-bottom: 20px !important;
 }
 h2 {
   font-family: $heading-font;
@@ -125,11 +91,29 @@ h2 {
   background: -webkit-linear-gradient(180deg, #91e9ee 0%, #06c1c0 100%);
   margin-bottom: 20px;
 }
+.sponsorCategory {
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  align-items: center;
+}
+.sponsorWrapper {
+  flex-grow: 1;
+  width: 200px;
+  padding: 30px;
+}
 .sponza {
   margin-top: 5%;
   text-align: center;
 }
 //Mobile CSS:
-@include until($desktop) {
+@include until($tablet) {
+  .sponsorCategory {
+    flex-direction: column;
+  }
+  .sponsorWrapper {
+    padding: 15px;
+  }
 }
 </style>

--- a/components/Sponza.vue
+++ b/components/Sponza.vue
@@ -99,9 +99,8 @@ h2 {
   align-items: center;
 }
 .sponsorWrapper {
-  flex-grow: 1;
   width: 200px;
-  padding: 30px;
+  margin: 25px;
 }
 .sponza {
   margin-top: 5%;
@@ -113,7 +112,7 @@ h2 {
     flex-direction: column;
   }
   .sponsorWrapper {
-    padding: 15px;
+    margin: 15px;
   }
 }
 </style>


### PR DESCRIPTION
I made all the images smaller because they looked too big to me.

The main bugs were caused by missing `max-height` and `top: -100` not being supported but I also trimmed down the code a bit.

Desktop
![image](https://user-images.githubusercontent.com/11839441/69894828-199b4c80-12da-11ea-8415-d7e64cd29bd3.png)

mobile stacks
![image](https://user-images.githubusercontent.com/11839441/69895481-3b4e0100-12e5-11ea-9c99-80c11f99b3aa.png)
