### PR TITLE
Sponsor Sizing

### DIFF
--- a/components/SponsorImage.vue
+++ b/components/SponsorImage.vue
@@ -50,7 +50,7 @@ img {
   display: block;
   position: relative;
 }
-.link img{
+.link img {
   transition: 0.5s, -moz-filter 0.5s, -o-filter 0.5s, filter 0.5s;
 }
 .link .hasAlt {
@@ -69,23 +69,23 @@ img {
   opacity: 0;
 }
 .tera {
-  max-width: 450px;
+  width: 450px;
   max-height: 270px;
 }
 .giga {
-  max-width: 390px;
+  width: 390px;
   max-height: 250px;
 }
 .mega {
-  max-width: 330px;
+  width: 330px;
   max-height: 230px;
 }
 .kilo {
-  max-width: 270px;
+  width: 270px;
   max-height: 210px;
 }
 .in-kind {
-  max-width: 225px;
+  width: 225px;
   max-height: 190px;
 }
 //Mobile CSS:

--- a/components/SponsorImage.vue
+++ b/components/SponsorImage.vue
@@ -40,7 +40,6 @@ export default {
   filter: brightness(0) invert(1);
 }
 img {
-  width: 100%;
   display: block;
 }
 .default:hover {
@@ -69,24 +68,24 @@ img {
   opacity: 0;
 }
 .tera {
-  width: 450px;
-  max-height: 270px;
+  max-width: 400px;
+  max-height: 260px;
 }
 .giga {
-  width: 390px;
-  max-height: 250px;
+  max-width: 360px;
+  max-height: 240px;
 }
 .mega {
-  width: 330px;
-  max-height: 230px;
+  max-width: 320px;
+  max-height: 220px;
 }
 .kilo {
-  width: 270px;
-  max-height: 210px;
+  max-width: 280px;
+  max-height: 200px;
 }
 .in-kind {
-  width: 225px;
-  max-height: 190px;
+  max-width: 240px;
+  max-height: 180px;
 }
 //Mobile CSS:
 @include until($tablet) {

--- a/components/SponsorImage.vue
+++ b/components/SponsorImage.vue
@@ -67,23 +67,23 @@ img {
   opacity: 0;
 }
 .tera {
-  max-width: 230px;
-  max-height: 230px;
+  max-width: 450px;
+  max-height: 270px;
 }
 .giga {
-  max-width: 200px;
-  max-height: 200px;
+  max-width: 390px;
+  max-height: 250px;
 }
 .mega {
-  max-width: 170px;
-  max-height: 170px;
+  max-width: 330px;
+  max-height: 230px;
 }
 .kilo {
-  max-width: 140px;
-  max-height: 140px;
+  max-width: 270px;
+  max-height: 210px;
 }
 .in-kind {
-  max-width: 110px;
-  max-height: 110px;
+  max-width: 225px;
+  max-height: 190px;
 }
 </style>

--- a/components/SponsorImage.vue
+++ b/components/SponsorImage.vue
@@ -91,6 +91,7 @@ img {
 @include until($tablet) {
   img {
     display: inline;
+    max-width: 200px !important;
   }
 }
 </style>

--- a/components/Sponza.vue
+++ b/components/Sponza.vue
@@ -121,6 +121,7 @@ h2 {
     flex-direction: column;
   }
   .sponsorWrapper {
+    max-width: 300px;
     margin: 15px;
   }
 }

--- a/components/Sponza.vue
+++ b/components/Sponza.vue
@@ -102,14 +102,14 @@ h2 {
   margin-bottom: 20px;
 }
 .sponsorCategory {
-  margin-bottom: 20px;
+  margin-bottom: 40px;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-evenly;
+  justify-content: center;
   align-items: center;
 }
 .sponsorWrapper {
-  margin: 10px;
+  margin: 30px;
 }
 .sponza {
   margin-top: 5%;
@@ -121,7 +121,7 @@ h2 {
     flex-direction: column;
   }
   .sponsorWrapper {
-    margin: 10px;
+    margin: 15px;
   }
 }
 </style>

--- a/components/Sponza.vue
+++ b/components/Sponza.vue
@@ -109,7 +109,6 @@ h2 {
   align-items: center;
 }
 .sponsorWrapper {
-  width: 200px;
   margin: 10px;
 }
 .sponza {

--- a/components/Sponza.vue
+++ b/components/Sponza.vue
@@ -53,11 +53,21 @@ export default {
     }
   },
   computed: {
-    listOfTera: function () { return this.items.filter(item => item.rank === 'tera') },
-    listOfGiga: function () { return this.items.filter(item => item.rank === 'giga') },
-    listOfMega: function () { return this.items.filter(item => item.rank === 'mega') },
-    listOfKilo: function () { return this.items.filter(item => item.rank === 'kilo') },
-    listOfInKind: function () { return this.items.filter(item => item.rank === 'in-kind') }
+    listOfTera: function () {
+      return this.items.filter(item => item.rank === 'tera')
+    },
+    listOfGiga: function () {
+      return this.items.filter(item => item.rank === 'giga')
+    },
+    listOfMega: function () {
+      return this.items.filter(item => item.rank === 'mega')
+    },
+    listOfKilo: function () {
+      return this.items.filter(item => item.rank === 'kilo')
+    },
+    listOfInKind: function () {
+      return this.items.filter(item => item.rank === 'in-kind')
+    }
   }
 }
 </script>
@@ -100,7 +110,7 @@ h2 {
 }
 .sponsorWrapper {
   width: 200px;
-  margin: 25px;
+  margin: 10px;
 }
 .sponza {
   margin-top: 5%;
@@ -112,7 +122,7 @@ h2 {
     flex-direction: column;
   }
   .sponsorWrapper {
-    margin: 15px;
+    margin: 10px;
   }
 }
 </style>


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #

---

## :construction_worker: Changes

Make sponsor sizing more better!

## :thought_balloon: Notes

The logo file for accenture in dev doesn't work in this fix. But it seems to work on staging. No idea why.

## :flashlight: Testing Instructions

Go to https://staging.nwplus.io/ and admire new sponsor sizing
