### PR TITLE
update default email

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -4,7 +4,7 @@
     <br>
     <p class="join-us-section">
       nwPlus is always looking for new ventures, opportunities, and connections. If you are interested in working with us, joining us or speaking at one of our events, feel free to reach out to us at
-      <a class="mail-to" href="mailto:hello@nwplus.io">hello@nwplus.io</a>
+      <a class="mail-to" href="mailto:info@nwplus.io">info@nwplus.io</a>
     </p>
   </div>
 </template>

--- a/components/realFooter.vue
+++ b/components/realFooter.vue
@@ -46,7 +46,7 @@
 
     <p class="links">
       <a
-        href="mailto:hello@nwplus.io"
+        href="mailto:info@nwplus.io"
       >Email Us</a>
       <a
         href="http://mlh.io/code-of-conduct"
@@ -55,7 +55,7 @@
       >
         Code of Conduct</a>
       <a
-        href="mailto:hello@nwplus.io?subject=Sponsorship"
+        href="mailto:info@nwplus.io?subject=Sponsorship"
       >Become a Sponsor</a>
     </p>
     <p


### PR DESCRIPTION
👷 Changes
A brief summary of what changes were introduced.

Changed default "reach us" email of nwplus
💭 Notes
Any additional things to take into consideration.
It wouldn't hurt anyone to change this. At worst if they finally figure out how to get access to hello@nwplus.io then info@nwplus.io can just forward email to that account

🔦 Testing Instructions
Explain how to test your changes, if applicable.
Just click on the link and check out the text.